### PR TITLE
Update app configuration to support sentry hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Use the Dockerfile in examples as a template and follow the instructions on how 
 the template for your own use. Then build and start the container:
 
 ```
-docker build -t metabrainz/datasethoster .
+docker build -t metabrainz/datasethoster -f example/Dockerfile .
 docker run -d -p 80:80 metabrainz/datasethoster
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then run this program and go to http://localhost:8000 !
 
 ```python
 from datasethoster import Query
-from datasethoster.main import app, register_query
+from datasethoster.main import create_app, register_query
 
 class ExampleQuery(Query):
 
@@ -47,6 +47,7 @@ class ExampleQuery(Query):
 register_query(ExampleQuery())
 
 if __name__ == "__main__":
+    app = create_app()
     app.run(host="0.0.0.0", port=8000, debug=True)
 ```
 

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -262,6 +262,7 @@ def json_query_handler_get():
     try:
         data = query.fetch(arg_list) if arg_list else []
     except Exception as err:
+        sentry_sdk.capture_exception(err)
         print(traceback.format_exc())
         return jsonify({}), 500
 
@@ -294,6 +295,7 @@ def json_query_handler_post():
     try:
         data = query.fetch(request.json, offset=offset, count=count) if request.json else []
     except Exception as err:
+        sentry_sdk.capture_exception(err)
         print(traceback.format_exc())
         return jsonify({ "error": err }), 400
 

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -29,7 +29,7 @@ def create_app(config_file=None):
     if config_file:
         app.config.from_object(config_file)
 
-    if 'SENTRY_DSN' in app.config:
+    if 'SENTRY_DSN' in app.config and app.config['SENTRY_DSN']:
         sentry_sdk.init(
             dsn=app.config['SENTRY_DSN'],
             integrations=[FlaskIntegration()]

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -24,14 +24,20 @@ dataset_bp = Blueprint('dataset_hoster', __name__, template_folder=TEMPLATE_FOLD
 
 
 def create_app(config_file=None):
+    """Create a flask app and optionally load a config file and initialise sentry"""
     app = Flask(__name__, template_folder=TEMPLATE_FOLDER)
     app.register_blueprint(dataset_bp)
     if config_file:
         app.config.from_object(config_file)
+    init_sentry(app)
+    return app
 
-    if 'SENTRY_DSN' in app.config and app.config['SENTRY_DSN']:
+
+def init_sentry(app, dsn_config='SENTRY_DSN'):
+    """Register sentry on the given app"""
+    if dsn_config in app.config and app.config[dsn_config]:
         sentry_sdk.init(
-            dsn=app.config['SENTRY_DSN'],
+            dsn=app.config[dsn_config],
             integrations=[FlaskIntegration()]
         )
 

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -190,6 +190,7 @@ def web_query_handler():
             except Exception as err:
                 error = traceback.format_exc()
                 print(error)
+                sentry_sdk.capture_exception(err)
 
             for i, arg in enumerate(data):
                 for output in outputs:

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -14,11 +14,13 @@ FROM tiangolo/uwsgi-nginx-flask:python3.8
 
 RUN apt-get update && apt-get install -y ca-certificates
 
-RUN mkdir /hoster
-WORKDIR /hoster
-COPY . /hoster
+COPY requirements.txt /app
 RUN python -m pip install -r requirements.txt
-# Change the COPY command below to copy any config files or other 
+
+COPY datasethoster /app/datasethoster
+
+# Change the COPY command below to copy any config files or other
 # modules you may need (e.g. config.py) to /app:
-COPY main.py config.py /app/
-RUN chmod +x /app/main.py
+COPY example/example.py example/main.py example/config.py example/uwsgi.ini /app/
+
+ENV FLASK_ENV=development

--- a/example/example.py
+++ b/example/example.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 
 from datasethoster import Query
-from datasethoster.main import app, register_query
+
 
 class ExampleQuery(Query):
 
+    def setup(self):
+        pass
+
     def names(self):
-        return ("example", "Useless arithmetic table example")
+        return "example", "Useless arithmetic table example"
 
     def introduction(self):
         return """This is the introduction, which could provide more useful info that this introduction does."""
@@ -26,8 +29,3 @@ class ExampleQuery(Query):
                             })
 
         return data
-
-
-if __name__ == "__main__":
-    register_query(ExampleQuery())
-    app.run(host="0.0.0.0", port=8001, debug=True)

--- a/example/main.py
+++ b/example/main.py
@@ -1,0 +1,11 @@
+from datasethoster.main import create_app, register_query
+
+from example import ExampleQuery
+
+app = create_app('config')
+
+register_query(ExampleQuery())
+
+if __name__ == "__main__":
+    # Only for debugging while developing
+    app.run(host='0.0.0.0', debug=True, port=80)

--- a/example/uwsgi.ini
+++ b/example/uwsgi.ini
@@ -1,0 +1,4 @@
+[uwsgi]
+module = main
+callable = app
+enable-threads = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==1.1.2
 pytest==5.4.3
 pytest-cov==2.10.0
 Flask-Testing==0.8.0
+sentry-sdk[flask]==0.19.3
+six

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(name='datasethoster',
       package_data={'datasethoster': ['template/*.html']},
       include_package_data=True,
       install_requires=[
-          'Flask==1.1.2',
+          'Flask==1.1.2', 'six', 'sentry-sdk[flask]==0.19.3'
       ],
       zip_safe=False)


### PR DESCRIPTION
This change allows you to configure sentry at app start up so that we can get details about errors when they occur.

In order to configure sentry when building the app, I had to move to a `create_app`-style setup like we use in the other python brainzes. I added a blueprint so that we can add routes without having an actual app instance. I also updated the example docker code to work with this api.
It means that in downstream apps (bono-datasets, and LB datasets), we will have to import create_app, and create the `app` module ourselves.

Note the change to uwsgi.ini, which enables threads. This is needed because of the sentry dependency.

Also added in sentry as a dependency in setup.py for this, and six which was missing and needed in the cors decorator.


Now that this code is in a branch online, I will test the bono and listenbrainz datasets with this setup. I'll confirm when I have success with those ones before we merge this.
