### PR TITLE
Use open-ended versions so that downstream projects can pin exact versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(name='datasethoster',
       package_data={'datasethoster': ['template/*.html']},
       include_package_data=True,
       install_requires=[
-          'Flask==1.1.2', 'six', 'sentry-sdk[flask]==0.19.3'
+          'Flask>=1.1.2', 'six', 'sentry-sdk[flask]>=0.19.3'
       ],
       zip_safe=False)


### PR DESCRIPTION
The changes follow the rationale of https://github.com/metabrainz/brainzutils-python/pull/45.