### PR TITLE
Add playlist support

### DIFF
--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -202,7 +202,7 @@ def web_query_handler():
                             pass
 
                     if output == "recording_mbid":
-                        recording_mbids.append(str(arg["recording_mbid"][:100]))
+                        recording_mbids.append(str(arg["recording_mbid"])[:100])
 
 
     json_url = request.url.replace(slug, slug + "/json")

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -202,7 +202,7 @@ def web_query_handler():
                             pass
 
                     if output == "recording_mbid":
-                        recording_mbids.append(str(arg["recording_mbid"])[:100])
+                        recording_mbids.append(str(arg["recording_mbid"]))
 
 
     json_url = request.url.replace(slug, slug + "/json")
@@ -218,7 +218,7 @@ def web_query_handler():
                            slug=slug,
                            json_url=json_url,
                            json_post=json_post,
-                           recording_mbids=",".join(recording_mbids))
+                           recording_mbids=",".join(recording_mbids[:100]))
 
 
 @crossdomain(headers=["Content-Type"])

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -202,7 +202,7 @@ def web_query_handler():
                             pass
 
                     if output == "recording_mbid":
-                        recording_mbids.append(str(arg["recording_mbid"]))
+                        recording_mbids.append(str(arg["recording_mbid"][:100]))
 
 
     json_url = request.url.replace(slug, slug + "/json")

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -172,6 +172,7 @@ def web_query_handler():
     outputs = query.outputs()
 
     data = []
+    recording_mbids = []
     json_post = ""
     arg_list, error = convert_http_args_to_json(inputs, request.args)
     if error:
@@ -200,6 +201,10 @@ def web_query_handler():
                         except KeyError:
                             pass
 
+                    if output == "recording_mbid":
+                        recording_mbids.append(arg["recording_mbid"])
+
+
     json_url = request.url.replace(slug, slug + "/json")
     return render_template("query.html",
                            error=error,
@@ -212,7 +217,8 @@ def web_query_handler():
                            desc=desc,
                            slug=slug,
                            json_url=json_url,
-                           json_post=json_post)
+                           json_post=json_post,
+                           recording_mbids=",".join(recording_mbids))
 
 
 @crossdomain(headers=["Content-Type"])

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -218,7 +218,7 @@ def web_query_handler():
                            slug=slug,
                            json_url=json_url,
                            json_post=json_post,
-                           recording_mbids=",".join(recording_mbids[:100]))
+                           recording_mbids=",".join(recording_mbids[:50]))
 
 
 @crossdomain(headers=["Content-Type"])

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -202,7 +202,7 @@ def web_query_handler():
                             pass
 
                     if output == "recording_mbid":
-                        recording_mbids.append(arg["recording_mbid"])
+                        recording_mbids.append(str(arg["recording_mbid"]))
 
 
     json_url = request.url.replace(slug, slug + "/json")

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -28,15 +28,20 @@
   </div>
 {% endif %}
 
+  <div>
 {% if count >= 0 %}
-    <p><b>{{ count }} rows returned</b></p>
+       <p><b>{{ count }} rows returned</b></p>
+{% else %}
+       <p><b>No results found</b></p>
 {% endif %}
+  </div>
 
 {% if recording_mbids %}
+  <div style="float: right">
     <a class="button"
        href="https://test.listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">Open results as a playlist</a>
+  </div>
 {% endif %}
-
 
 {% if data %}
   <table>

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -32,6 +32,12 @@
     <p><b>{{ count }} rows returned</b></p>
 {% endif %}
 
+{% if recording_mbids %}
+    <a class="button"
+       href="https://test.listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">Open results as a playlist</a>
+{% endif %}
+
+
 {% if data %}
   <table>
     <thead>

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -31,7 +31,7 @@
 {% if recording_mbids %}
   <div style="float: right">
     <a class="button" target="_blank"
-       href="https://test.listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">Open results as a playlist</a>
+       href="https://listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">Open results as a playlist</a>
   </div>
 {% endif %}
 

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -28,6 +28,14 @@
   </div>
 {% endif %}
 
+{% if recording_mbids %}
+  <div style="float: right">
+    <a class="button" target="_blank"
+       href="https://test.listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">Open results as a playlist</a>
+  </div>
+{% endif %}
+
+
   <div>
 {% if count >= 0 %}
        <p><b>{{ count }} rows returned</b></p>
@@ -35,13 +43,6 @@
        <p><b>No results found</b></p>
 {% endif %}
   </div>
-
-{% if recording_mbids %}
-  <div style="float: right">
-    <a class="button"
-       href="https://test.listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">Open results as a playlist</a>
-  </div>
-{% endif %}
 
 {% if data %}
   <table>

--- a/datasethoster/tests/test_views.py
+++ b/datasethoster/tests/test_views.py
@@ -109,7 +109,6 @@ class MainTestCase(flask_testing.TestCase):
         ]
         resp = self.client.post(url_for('dataset_hoster.test_json'), json=req_args)
         self.assert200(resp)
-        print(resp.data)
         self.assertEqual(len(resp.json), 2)
         self.assertEqual(resp.json[0]['out_0'], 'value0')
         self.assertEqual(resp.json[0]['[out_1]'], ['value1', 'value3'])


### PR DESCRIPTION
This PR adds playlist support and adds one minor enhancement:

- If a result set includes recording_mbid as an output, the recording_mbids are collected and a link to an LB instant playlist is put at the top of the results.
- If no results are produced by the query, say that.