### PR TITLE
Add query summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,11 @@ derived from the Query object and override the following functions:
          passed in parameters, the function should carry out more error checking
          on the arguments and then fetch the data needed. This function should
          return a list of dicts with keys named exactly after each of the
-         outputs. For the POST method endpoint the arguments count and
+         outputs.
+         Alternatively, return a tuple of (data, summary), and the summary will
+         be displayed as HTML above the results. Use this to return additional
+         information about the queries, such timing or debug information.
+         For the POST method endpoint the arguments count and
          offset may be provided -- for the web view and GET JSON views, offset
          and count are not handled.
 

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -187,10 +187,12 @@ def web_query_handler():
 
             try:
                 data = query.fetch(arg_list) if arg_list else []
-                if type(data) == list:
-                    summary = None
-                else:
+                if type(data) == tuple:
+                    if len(data) != 2:
+                        raise InternalServerError("Query's .fetch() method returned tuple that didn't have exactly 2 elements")
                     data, summary = data
+                else:
+                    summary = None
             except (BadRequest, InternalServerError, ImATeapot, ServiceUnavailable, NotFound) as err:
                 error = err
             except Exception as err:
@@ -273,6 +275,8 @@ def json_query_handler_get():
     try:
         data = query.fetch(arg_list) if arg_list else []
         if type(data) == tuple:
+            if len(data) != 2:
+                raise InternalServerError("Query's .fetch() method returned tuple that didn't have exactly 2 elements")
             data, _ = data
     except Exception as err:
         sentry_sdk.capture_exception(err)
@@ -308,6 +312,8 @@ def json_query_handler_post():
     try:
         data = query.fetch(request.json, offset=offset, count=count) if request.json else []
         if type(data) == tuple:
+            if len(data) != 2:
+                raise InternalServerError("Query's .fetch() method returned tuple that didn't have exactly 2 elements")
             data, _ = data
     except Exception as err:
         sentry_sdk.capture_exception(err)

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -188,7 +188,7 @@ def web_query_handler():
                 data = query.fetch(arg_list) if arg_list else []
                 if type(data) == dict:
                     summary = None
-                else type(data) == tuple:
+                else:
                     data, summary = data
             except (BadRequest, InternalServerError, ImATeapot, ServiceUnavailable, NotFound) as err:
                 error = err

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -171,7 +171,7 @@ def web_query_handler():
     inputs = query.inputs()
     outputs = query.outputs()
 
-    data = []
+    data = None
     recording_mbids = []
     json_post = ""
     arg_list, error = convert_http_args_to_json(inputs, request.args)

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -197,7 +197,7 @@ def web_query_handler():
                 error = traceback.format_exc()
                 sentry_sdk.capture_exception(err)
 
-            for i, arg in enumerate(data):
+            for i, arg in enumerate(data or []):
                 for output in outputs:
                     if output[0] == '[' and output[-1] == ']':
                         try:

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -172,6 +172,7 @@ def web_query_handler():
     outputs = query.outputs()
 
     data = None
+    summary = None
     recording_mbids = []
     json_post = ""
     arg_list, error = convert_http_args_to_json(inputs, request.args)

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -186,11 +186,14 @@ def web_query_handler():
 
             try:
                 data = query.fetch(arg_list) if arg_list else []
+                if type(data) == dict:
+                    summary = None
+                else type(data) == tuple:
+                    data, summary = data
             except (BadRequest, InternalServerError, ImATeapot, ServiceUnavailable, NotFound) as err:
                 error = err
             except Exception as err:
                 error = traceback.format_exc()
-                print(error)
                 sentry_sdk.capture_exception(err)
 
             for i, arg in enumerate(data):
@@ -209,6 +212,7 @@ def web_query_handler():
     return render_template("query.html",
                            error=error,
                            data=data,
+                           summary=summary,
                            count=len(data) if data else -1,
                            inputs=inputs,
                            columns=outputs,
@@ -267,6 +271,8 @@ def json_query_handler_get():
 
     try:
         data = query.fetch(arg_list) if arg_list else []
+        if type(data) == tuple:
+            data, _ = data
     except Exception as err:
         sentry_sdk.capture_exception(err)
         print(traceback.format_exc())
@@ -300,6 +306,8 @@ def json_query_handler_post():
 
     try:
         data = query.fetch(request.json, offset=offset, count=count) if request.json else []
+        if type(data) == tuple:
+            data, _ = data
     except Exception as err:
         sentry_sdk.capture_exception(err)
         print(traceback.format_exc())

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -187,7 +187,7 @@ def web_query_handler():
 
             try:
                 data = query.fetch(arg_list) if arg_list else []
-                if type(data) == dict:
+                if type(data) == list:
                     summary = None
                 else:
                     data, summary = data

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -36,13 +36,21 @@
 {% endif %}
 
 
-  <div>
-{% if count >= 0 %}
-       <p><b>{{ count }} rows returned</b></p>
-{% else %}
-       <p><b>No results found</b></p>
+{% if data is not None %}
+    <div>
+  {% if count >= 0 %}
+         <p><b>{{ count }} rows returned</b></p>
+  {% else %}
+         <p><b>No results found</b></p>
+  {% endif %}
+    </div>
 {% endif %}
-  </div>
+
+{% if summary is not None %}
+    <div>
+       {{ summary }}
+    </div>
+{% endif %}
 
 {% if data %}
   <table>

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -48,7 +48,7 @@
 
 {% if summary is not none %}
     <div>
-       {{ summary }}
+       {{ summary|safe }}
     </div>
 {% endif %}
 

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -46,7 +46,7 @@
     </div>
 {% endif %}
 
-{% if summary is not None %}
+{% if summary is not none %}
     <div>
        {{ summary }}
     </div>

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -36,7 +36,7 @@
 {% endif %}
 
 
-{% if data is not None %}
+{% if data is not none %}
     <div>
   {% if count >= 0 %}
          <p><b>{{ count }} rows returned</b></p>


### PR DESCRIPTION
This PR allows a query to optionally return a tuple(data, summary) or just data. If summary is returned it is treated as an HTML field that will be displayed above the query results.

The goal of this feature is for a query to provide extra information about the queries, such a timing information.