### PR TITLE
Allow input items to have a comma by using csv module to parse

### DIFF
--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -1,8 +1,8 @@
-from collections import defaultdict
 import copy
+import csv
+import io
 import json
 import os
-import sys
 import traceback
 
 from flask import Blueprint, Flask, render_template, request, jsonify
@@ -95,7 +95,7 @@ def convert_http_args_to_json(inputs, req_args):
     list_len = -1
     for arg, input in zip(req_args, inputs):
         if input[0] == '[':
-            args[arg] = req_args[arg].split(",")
+            args[arg] = next(csv.reader(io.StringIO(req_args[arg])))
         else:
             args[arg] = [ req_args[arg] ]
         list_len = max(list_len, len(args[arg]))

--- a/datasethoster/tests/test_views.py
+++ b/datasethoster/tests/test_views.py
@@ -66,8 +66,9 @@ class MainTestCase(flask_testing.TestCase):
     def test_empty_query_page(self):
         q = SampleQuery()
         register_query(q)
-        # Re-register the blueprint to add the new urls that were added with SampleQuery
-        dataset_bp.register(current_app, {}, first_registration=False)
+        # Delete the blueprint so that it can be re-registered with the urls that were added with SampleQuery
+        del self.app.blueprints['dataset_hoster']
+        dataset_bp.register(current_app, {})
 
         resp = self.client.get(url_for('dataset_hoster.test'))
         self.assert200(resp)

--- a/datasethoster/tests/test_views.py
+++ b/datasethoster/tests/test_views.py
@@ -1,3 +1,4 @@
+import unittest.mock
 from unittest.mock import patch, call
 
 import flask_testing
@@ -82,6 +83,24 @@ class MainTestCase(flask_testing.TestCase):
         register_query(q)
         params = { 'in_0':'value0', '[in_1]': 'value1,value2' }
         resp = self.client.get(url_for('dataset_hoster.test', **params))
+        self.assert200(resp)
+
+    def test_web_query_multiple(self):
+        # Check that multiple items can be passed in for a field with "val1,val2"
+        # and that if a value has a , in it, the field can be quoted
+        q = SampleQuery()
+        register_query(q)
+        q.fetch = unittest.mock.Mock()
+        q.fetch.return_value = [{'out_0': 'one', '[out_1]': ['two', 'three']}]
+
+        params = { 'in_0':'value0', '[in_1]': 'value1,value2' }
+        resp = self.client.get(url_for('dataset_hoster.test', **params))
+        q.fetch.assert_called_with([{'in_0': 'value0', '[in_1]': 'value1'}, {'in_0': 'value0', '[in_1]': 'value2'}])
+
+        params = { 'in_0':'value0', '[in_1]': 'value1,"value2,value3"' }
+        resp = self.client.get(url_for('dataset_hoster.test', **params))
+        q.fetch.assert_called_with([{'in_0': 'value0', '[in_1]': 'value1'}, {'in_0': 'value0', '[in_1]': 'value2,value3'}])
+
         self.assert200(resp)
 
     def test_json_get(self):

--- a/example/example.py
+++ b/example/example.py
@@ -20,15 +20,15 @@ class ExampleQuery(Query):
     def outputs(self):
         return ['number', 'multiplied']
 
-    def fetch(self, args, offset=-1, limit=-1):
+    def fetch(self, params, offset=-1, limit=-1):
         data = []
         try:
-            number = int(arg['number'])
+            number = int(params[0]['number'])
         except ValueError:
             number = 1
 
-        for arg in args:
-            for i in range(int(arg['num_lines'])):
+        for param in params:
+            for i in range(int(param['num_lines'])):
                 data.append({ 'number': str(i),
                               'multiplied': str(i * number)
                             })

--- a/example/main.py
+++ b/example/main.py
@@ -2,9 +2,10 @@ from datasethoster.main import create_app, register_query
 
 from example import ExampleQuery
 
-app = create_app('config')
-
 register_query(ExampleQuery())
+
+# Needs to be after register_query
+app = create_app('config')
 
 if __name__ == "__main__":
     # Only for debugging while developing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask==1.1.2
+Flask==2.1.3
 pytest==5.4.3
 pytest-cov==2.10.0
-Flask-Testing==0.8.0
+Flask-Testing==0.8.1
 sentry-sdk[flask]==0.19.3
 six

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(name='datasethoster',
       package_data={'datasethoster': ['template/*.html']},
       include_package_data=True,
       install_requires=[
-          'Flask>=1.1.2', 'six', 'sentry-sdk[flask]>=0.19.3'
+          'Flask>=2.1.3', 'six', 'sentry-sdk[flask]>=0.19.3'
       ],
       zip_safe=False)


### PR DESCRIPTION
Sometimes we might want to put a comma in a parameter in the html interface
If the input is defined as a multiple input, we split on comma which means this input gets split in unexpected places (and causes an error "Lists passed as parameters must all be the same length")

e.g.

    [artist_credit_name]=Belle and Sebastian
    [recording_name]=Piazza, New York Catcher

Fix this by using the csv module to parse these inputs. If a value has a comma in it, it can be quoted to prevent splitting:

    [artist_credit_name]=Belle and Sebastian,another artist
    [recording_name]="Piazza, New York Catcher",another song

This only affects the html interface, the json endpoint is already split into lists and so we don't try to split it.