### PR TITLE
Add support for more flexible outputs

### DIFF
--- a/datasethoster/__init__.py
+++ b/datasethoster/__init__.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 
 
-class Query():
+class Query:
 
     def __init__(self):
         """ The constructor, override it if you need to. """
@@ -33,7 +33,9 @@ class Query():
 
     @abstractmethod
     def outputs(self):
-        """ return a list of text column names that will be returned by the fetch function """
+        """ return a list of text column names that will be returned by the fetch function.
+            return None if the outputs are dynamic and you want those to be inferred.
+        """
         pass
 
     @abstractmethod

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -171,8 +171,6 @@ def web_query_handler():
     inputs = query.inputs()
     outputs = query.outputs()
 
-    data = None
-    recording_mbids = []
     results = []
     json_post = ""
     arg_list, error = convert_http_args_to_json(inputs, request.args)
@@ -201,16 +199,6 @@ def web_query_handler():
             except Exception as err:
                 error = traceback.format_exc()
                 sentry_sdk.capture_exception(err)
-
-            # TODO: check whether needed, if so move to per output
-            if outputs:
-                for i, arg in enumerate(data or []):
-                    for output in outputs:
-                        if output[0] == '[' and output[-1] == ']':
-                            try:
-                                arg[output] = ",".join(arg[output] or "")
-                            except KeyError:
-                                pass
 
     json_url = request.url.replace(slug, slug + "/json")
     return render_template(

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -202,16 +202,15 @@ def web_query_handler():
                 error = traceback.format_exc()
                 sentry_sdk.capture_exception(err)
 
-            for i, arg in enumerate(data or []):
-                for output in outputs:
-                    if output[0] == '[' and output[-1] == ']':
-                        try:
-                            arg[output] = ",".join(arg[output] or "")
-                        except KeyError:
-                            pass
-
-                    if output == "recording_mbid":
-                        recording_mbids.append(str(arg["recording_mbid"]))
+            # TODO: check whether needed, if so move to per output
+            if outputs:
+                for i, arg in enumerate(data or []):
+                    for output in outputs:
+                        if output[0] == '[' and output[-1] == ']':
+                            try:
+                                arg[output] = ",".join(arg[output] or "")
+                            except KeyError:
+                                pass
 
     json_url = request.url.replace(slug, slug + "/json")
     return render_template(

--- a/datasethoster/template/macros.html
+++ b/datasethoster/template/macros.html
@@ -1,6 +1,9 @@
 {% macro link_mb(entity, value) %}
   {% if value %}
-    <a href="https://musicbrainz.org/{{ entity }}/{{ value }}">{{ value }}</a>
+    <a href="https://musicbrainz.org/{{ entity }}/{{ value }}"
+       target="_blank" rel="noopener noreferrer">
+      {{ value }}
+    </a>
   {% else %}
     {{ value }}
   {% endif %}
@@ -12,7 +15,7 @@
       {% set recording_mbids = output.data[:50] | selectattr('recording_mbid') | join(',', 'recording_mbid') %}
       {% if recording_mbids %}
         <div style="float: right">
-          <a class="button" target="_blank"
+          <a class="button" target="_blank" rel="noopener noreferrer"
              href="https://listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">
             Open results as a playlist
           </a>

--- a/datasethoster/template/macros.html
+++ b/datasethoster/template/macros.html
@@ -10,8 +10,9 @@
   {% if output %}
     {% if "recording_mbid" in output.columns %}
       <div style="float: right">
+        {% set recording_mbids = output.data[:50] | selectattr('recording_mbid') | join(',', 'recording_mbid') %}
         <a class="button" target="_blank"
-           href="https://listenbrainz.org/player/?recording_mbids={{ output.data[:50]|join(',', 'recording_mbid') }}">
+           href="https://listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">
           Open results as a playlist
         </a>
       </div>

--- a/datasethoster/template/macros.html
+++ b/datasethoster/template/macros.html
@@ -1,0 +1,59 @@
+{% macro format_output(output) %}
+  {% if output %}
+    {% if "recording_mbid" in output.columns %}
+      <div style="float: right">
+        <a class="button" target="_blank"
+           href="https://listenbrainz.org/player/?recording_mbids={{ output.data[:50]|join(',', 'recording_mbid') }}">
+          Open results as a playlist
+        </a>
+      </div>
+    {% endif %}
+    <div>
+      {% set count = output.data | length %}
+      {% if count %}
+        <p><b>{{ count }} rows returned</b></p>
+      {% else %}
+        <p><b>No results found</b></p>
+      {% endif %}
+    </div>
+    <table>
+      <thead>
+      <tr>
+        {% for column in output.columns %}
+          <th>{{ column }}</th>
+        {% endfor %}
+      </tr>
+      </thead>
+      <tbody>
+      {% for row in output.data %}
+        <tr>
+          {% for column in output.columns %}
+            {% set value = row[column]|join(',') if column[0] == '[' and column[-1] == ']' else row[column] %}
+            {% if column.endswith("recording_mbid") or column.endswith("recording_id") %}
+              <td><a href="https://musicbrainz.org/recording/{{ row[column] }}">{{ row[column] }}</a></td>
+            {% elif column.endswith("release_mbid") or column.endswith("release_id") %}
+              <td><a href="https://musicbrainz.org/release/{{ row[column] }}">{{ row[column] }}</a></td>
+            {% elif column.endswith("release_group_mbid") or column.endswith("release_group_id") %}
+              <td><a href="https://musicbrainz.org/release-group/{{ row[column] }}">{{ row[column] }}</a></td>
+            {% elif column.endswith("artist_mbid") or column.endswith("artist_id") or column.endswith("artist_credit_id") %}
+              <td><a href="https://musicbrainz.org/artist/{{ row[column] }}">{{ row[column] }}</a></td>
+            {% elif column.endswith("_json") %}
+              <td>
+                <pre>{{ row[column] }}</pre>
+              </td>
+            {% elif row[column] is iterable and row[column] is not string %}
+              <td>
+                {% for v in row[column] %}
+                  {{ v }}
+                {% endfor %}
+              </td>
+            {% else %}
+              <td>{{ row[column] }}</td>
+            {% endif %}
+          {% endfor %}
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+{% endmacro %}

--- a/datasethoster/template/macros.html
+++ b/datasethoster/template/macros.html
@@ -1,3 +1,11 @@
+{% macro link_mb(entity, value) %}
+  {% if value %}
+    <a href="https://musicbrainz.org/{{ entity }}/{{ value }}">{{ value }}</a>
+  {% else %}
+    {{ value }}
+  {% endif %}
+{% endmacro %}
+
 {% macro format_output(output) %}
   {% if output %}
     {% if "recording_mbid" in output.columns %}
@@ -30,13 +38,13 @@
           {% for column in output.columns %}
             {% set value = row[column]|join(',') if column[0] == '[' and column[-1] == ']' else row[column] %}
             {% if column.endswith("recording_mbid") or column.endswith("recording_id") %}
-              <td><a href="https://musicbrainz.org/recording/{{ row[column] }}">{{ row[column] }}</a></td>
+              <td>{{ link_mb('recording', row[column]) }}</td>
             {% elif column.endswith("release_mbid") or column.endswith("release_id") %}
-              <td><a href="https://musicbrainz.org/release/{{ row[column] }}">{{ row[column] }}</a></td>
+              <td>{{ link_mb('release', row[column]) }}</td>
             {% elif column.endswith("release_group_mbid") or column.endswith("release_group_id") %}
-              <td><a href="https://musicbrainz.org/release-group/{{ row[column] }}">{{ row[column] }}</a></td>
+              <td>{{ link_mb('release-group', row[column]) }}</td>
             {% elif column.endswith("artist_mbid") or column.endswith("artist_id") or column.endswith("artist_credit_id") %}
-              <td><a href="https://musicbrainz.org/artist/{{ row[column] }}">{{ row[column] }}</a></td>
+              <td>{{ link_mb('artist', row[column]) }}</td>
             {% elif column.endswith("_json") %}
               <td>
                 <pre>{{ row[column] }}</pre>

--- a/datasethoster/template/macros.html
+++ b/datasethoster/template/macros.html
@@ -9,13 +9,15 @@
 {% macro format_output(output) %}
   {% if output %}
     {% if "recording_mbid" in output.columns %}
-      <div style="float: right">
-        {% set recording_mbids = output.data[:50] | selectattr('recording_mbid') | join(',', 'recording_mbid') %}
-        <a class="button" target="_blank"
-           href="https://listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">
-          Open results as a playlist
-        </a>
-      </div>
+      {% set recording_mbids = output.data[:50] | selectattr('recording_mbid') | join(',', 'recording_mbid') %}
+      {% if recording_mbids %}
+        <div style="float: right">
+          <a class="button" target="_blank"
+             href="https://listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">
+            Open results as a playlist
+          </a>
+        </div>
+      {% endif %}
     {% endif %}
     <div>
       {% set count = output.data | length %}

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -29,13 +29,6 @@
   </div>
 {% endif %}
 
-{% if recording_mbids %}
-  <div style="float: right">
-    <a class="button" target="_blank"
-       href="https://listenbrainz.org/player/?recording_mbids={{ recording_mbids }}">Open results as a playlist</a>
-  </div>
-{% endif %}
-
 <div>
   {% for result in results %}
     {% if result.type == "markup" %}

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -58,5 +58,7 @@
   {% endif %}
 </div>
 
+{% endblock %}
+
 {% block scripts %}
 {% endblock %}

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -1,4 +1,5 @@
 {%- extends 'base.html' -%}
+{%- from 'macros.html' import format_output -%}
 {%- block title -%}{{ slug }}{% endblock %}
 {%- block content -%}
 
@@ -12,9 +13,9 @@
 <form action="/{{ slug }}">
   {% for input in inputs %}
      <label for="{{ input }}">{{ input }}</label>
-     <input type="text" 
-            id="{{ input }}" 
-            name="{{ input }}" 
+     <input type="text"
+            id="{{ input }}"
+            name="{{ input }}"
             placeholder="{% if input[0] == '[' %}list of items{% else %}single value{% endif %}"
             value="{{args[input] | escape }}"><br>
   {% endfor %}
@@ -35,71 +36,27 @@
   </div>
 {% endif %}
 
+<div>
+  {% for result in results %}
+    {% if result.type == "markup" %}
+      {{ result.data }}
+    {% elif result.type == "dataset" %}
+      {{ format_output(result) }}
+    {% else %}
+      <p><b>INVALID OUTPUT TYPE: PLEASE FIX! (RENDERING AS IS FOR NOW)</b></p>
+      {{ result }}
+    {% endif %}
+  {% endfor %}
 
-{% if data is not none %}
-    <div>
-  {% if count >= 0 %}
-         <p><b>{{ count }} rows returned</b></p>
-  {% else %}
-         <p><b>No results found</b></p>
-  {% endif %}
-    </div>
-{% endif %}
-
-{% if summary is not none %}
-    <div>
-       {{ summary|safe }}
-    </div>
-{% endif %}
-
-{% if data %}
-  <table>
-    <thead>
-      <tr>
-        {% for column in columns %}
-          <th>{{ column }}</th>
-        {% endfor %}
-      </tr>
-    </thead>
-    <tbody>
-      {% for row in data %}
-        <tr>
-          {% for column in columns %}
-            {% if column.endswith("recording_mbid") or column.endswith("recording_id")  %}
-              <td><a href="https://musicbrainz.org/recording/{{ row[column] }}">{{ row[column] }}</a></td>
-            {% elif column.endswith("release_mbid") or column.endswith("release_id")  %}
-              <td><a href="https://musicbrainz.org/release/{{ row[column] }}">{{ row[column] }}</a></td>
-            {% elif column.endswith("release_group_mbid") or column.endswith("release_group_id") %}
-              <td><a href="https://musicbrainz.org/release-group/{{ row[column] }}">{{ row[column] }}</a></td>
-            {% elif column.endswith("artist_mbid") or column.endswith("artist_id") or column.endswith("artist_credit_id") %}
-              <td><a href="https://musicbrainz.org/artist/{{ row[column] }}">{{ row[column] }}</a></td>
-            {% elif column.endswith("_json") %}
-              <td><pre>{{ row[column] }}</pre></td>
-            {% elif row[column] is iterable and row[column] is not string  %} 
-              <td>
-                {% for v in row[column] %}
-                    {{ v }}
-                {% endfor %}
-              </td>
-            {% else %}
-              <td>{{ row[column] }}</td>
-            {% endif %}
-          {% endfor %}
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
   {% if json_post %}
-     <div style="padding-top: 3em">
-       <small>JSON POST data for this query:</small>
-       <div id="json-post">
-          <pre style="background-color: #FFF">{{ json_post }}</pre>
-       </div>
-     </div>
+    <div style="padding-top: 3em">
+      <small>JSON POST data for this query:</small>
+      <div id="json-post">
+        <pre style="background-color: #FFF">{{ json_post }}</pre>
+      </div>
+    </div>
   {% endif %}
-{% endif %}
-
-{% endblock%}
+</div>
 
 {% block scripts %}
 {% endblock %}

--- a/example/example.py
+++ b/example/example.py
@@ -20,7 +20,7 @@ class ExampleQuery(Query):
     def outputs(self):
         return ['number', 'multiplied']
 
-    def fetch(self, params, offset=-1, limit=-1):
+    def fetch(self, params, offset=-1, count=-1):
         data = []
         try:
             number = int(params[0]['number'])
@@ -28,6 +28,7 @@ class ExampleQuery(Query):
             number = 1
 
         for param in params:
+            print(param)
             for i in range(int(param['num_lines'])):
                 data.append({ 'number': str(i),
                               'multiplied': str(i * number)


### PR DESCRIPTION
## Background
For the [sessions viewer](https://labs.api.listenbrainz.org/sessions-viewer?user_name=lucifer&from_ts=1664586061&to_ts=1666247407&threshold=300) query, I needed to created multiple tables. The existing data, summary output is not flexible enough to allow that.

## New Data Format
Augmenting the output format to support queries returning multiple outputs. The new output format is as follows:

1. A list of dicts
2. Each dict can be either of the follow two options

    1. A `dataset` that will displayed as a table. The `columns` field of the dict decides the table headers. The `data` field is a list of dicts, each dict of which represents the rows of the table. The keys of these dicts should match the fields in the columns list.
        ```
        {
            "type": "dataset",
            "columns": outputs,
            "data": data
        }
        ```
    2. A `markup` that will be rendered as is. The data field should be a `jinja2.Markup` or a plain string in this case.
        ```
        {
            "type": "markup",
            "data": data
        }
        ```
## Compatibility
Not every query needs to returns multiple datasets. To ensure that existing queries keep working and maintain simplicity where possible, the existing output method is still supported. Queries that return **non-null `outputs`** will assumed to be using the 1 dataset format. To use the new dataset format, the query should return **outputs** as `None`.