### PR TITLE
Add redirect support

### DIFF
--- a/datasethoster/exceptions.py
+++ b/datasethoster/exceptions.py
@@ -1,0 +1,6 @@
+class RedirectError(Exception):
+    """ Indicates that we should redirect to a new URL instead of show results. """
+
+    def __init__(self, url):
+        self.url = url
+        super().__init__()

--- a/datasethoster/exceptions.py
+++ b/datasethoster/exceptions.py
@@ -4,3 +4,6 @@ class RedirectError(Exception):
     def __init__(self, url):
         self.url = url
         super().__init__()
+
+class QueryError(Exception):
+    """ An error occured during the execution of the query and the error should be shown to the user. """

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -5,7 +5,7 @@ import json
 import os
 import traceback
 
-from flask import Blueprint, Flask, render_template, request, jsonify
+from flask import Blueprint, Flask, render_template, request, jsonify, redirect
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from werkzeug.exceptions import NotFound, BadRequest, InternalServerError, \

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import NotFound, BadRequest, InternalServerError, \
                                 MethodNotAllowed, ImATeapot, ServiceUnavailable
 
 from datasethoster.decorators import crossdomain
+from datasethoster.exceptions import RedirectError
 
 DEFAULT_QUERY_RESULT_SIZE = 100
 TEMPLATE_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), "template")
@@ -198,6 +199,8 @@ def web_query_handler():
                     ]
                 else:
                     results = data
+            except RedirectError as red:
+                return redirect(red.url)
             except (BadRequest, InternalServerError, ImATeapot, ServiceUnavailable, NotFound) as err:
                 error = err
             except Exception as err:

--- a/datasethoster/main.py
+++ b/datasethoster/main.py
@@ -12,7 +12,7 @@ from werkzeug.exceptions import NotFound, BadRequest, InternalServerError, \
                                 MethodNotAllowed, ImATeapot, ServiceUnavailable
 
 from datasethoster.decorators import crossdomain
-from datasethoster.exceptions import RedirectError
+from datasethoster.exceptions import RedirectError, QueryError
 
 DEFAULT_QUERY_RESULT_SIZE = 100
 TEMPLATE_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), "template")
@@ -201,6 +201,8 @@ def web_query_handler():
                     results = data
             except RedirectError as red:
                 return redirect(red.url)
+            except QueryError as err:
+                error = err
             except (BadRequest, InternalServerError, ImATeapot, ServiceUnavailable, NotFound) as err:
                 error = err
             except Exception as err:


### PR DESCRIPTION
Any query can now raise RedirectError(url) and the DSH will send the user to that URL instead of showing the results of the query. Useful for things like generating playlists. See in action here: https://datasets.listenbrainz.org/artist-radio