### PR TITLE
Queries to be used in dropdown for similar results

### DIFF
--- a/datasethoster/template/macros.html
+++ b/datasethoster/template/macros.html
@@ -9,6 +9,44 @@
   {% endif %}
 {% endmacro %}
 
+{% macro format_column(row, column) %}
+  {% if column.endswith("recording_mbid") or column.endswith("recording_id") %}
+    {{ link_mb('recording', row[column]) }}
+  {% elif column.endswith("release_mbid") or column.endswith("release_id") %}
+    {{ link_mb('release', row[column]) }}
+  {% elif column.endswith("release_group_mbid") or column.endswith("release_group_id") %}
+    {{ link_mb('release-group', row[column]) }}
+  {% elif column.endswith("artist_mbid") %}
+    {{ link_mb('artist', row[column]) }}
+  {% elif column.endswith("artist_credit_mbids") and row[column] is iterable %}
+    {% for v in row[column] %}
+      {{ link_mb('artist', v) }}
+    {% endfor %}
+  {% elif column.endswith("_json") %}
+    <pre>{{ row[column] }}</pre>
+  {% elif row[column] is iterable and row[column] is not string %}
+    {% for v in row[column] %}
+      {{ v }}
+    {% endfor %}
+  {% else %}
+    {{ row[column] }}
+  {% endif %}
+{% endmacro %}
+
+{% macro format_dropdown(row_idx, col_idx, column, links) %}
+  {% set dropdown_id = "" %}
+  <div id="dropdown-{{ column }}-{{ row_idx }}-{{ col_idx }}" class="dropdown">
+    <button onclick="toggleDropdown('dropdown-{{ column }}-{{ row_idx }}-{{ col_idx }}')" class="dropdown_button">
+      <span class="arrow"></span>
+    </button>
+    <div class="dropdown-content">
+      {% for name, url in links %}
+        <a href="{{ url }}">{{ name }}</a>
+      {% endfor %}
+    </div>
+  </div>
+{% endmacro %}
+
 {% macro format_output(output, additional_data) %}
   {% if output %}
     {% if "recording_mbid" in output.columns %}
@@ -41,36 +79,18 @@
       </tr>
       </thead>
       <tbody>
-      {% for row in output.data %}
+      {% for row, links in output.data|zip(output.links) %}
         <tr>
+          {% set rowloop = loop %}
           {% for column in output.columns %}
-            {% if column.endswith("recording_mbid") or column.endswith("recording_id") %}
-              <td>{{ link_mb('recording', row[column]) }}</td>
-            {% elif column.endswith("release_mbid") or column.endswith("release_id") %}
-              <td>{{ link_mb('release', row[column]) }}</td>
-            {% elif column.endswith("release_group_mbid") or column.endswith("release_group_id") %}
-              <td>{{ link_mb('release-group', row[column]) }}</td>
-            {% elif column.endswith("artist_mbid") %}
-              <td>{{ link_mb('artist', row[column]) }}</td>
-            {% elif column.endswith("artist_credit_mbids") and row[column] is iterable %}
-              <td>
-                {% for v in row[column] %}
-                  {{ link_mb('artist', v) }}
-                {% endfor %}
-              </td>
-            {% elif column.endswith("_json") %}
-              <td>
-                <pre>{{ row[column] }}</pre>
-              </td>
-            {% elif row[column] is iterable and row[column] is not string %}
-              <td>
-                {% for v in row[column] %}
-                  {{ v }}
-                {% endfor %}
-              </td>
-            {% else %}
-              <td>{{ row[column] }}</td>
-            {% endif %}
+            <td>
+              <div class="item-container">
+                <div class="item-content">{{ format_column(row, column) }}</div>
+                {% if links.get(column) %}
+                  {{ format_dropdown(rowloop.index, loop.index, column, links.get(column)) }}
+                {% endif %}
+              </div>
+            </td>
           {% endfor %}
         </tr>
       {% endfor %}

--- a/datasethoster/template/query.html
+++ b/datasethoster/template/query.html
@@ -1,6 +1,75 @@
 {%- extends 'base.html' -%}
 {%- from 'macros.html' import format_output -%}
 {%- block title -%}{{ slug }}{% endblock %}
+{% block styles %}
+  {{ super() }}
+  <style>
+  .dropdown-content {
+      display: none;
+      position: absolute;
+      background-color: #f1f1f1;
+      min-width: 160px;
+      overflow: auto;
+      box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
+      z-index: 1;
+  }
+
+  .dropdown-content a {
+      color: black;
+      padding: 12px 16px;
+      text-decoration: none;
+      display: block;
+  }
+
+  .dropdown a:hover {
+      background-color: #ddd;
+      display: inline-block;
+  }
+
+  .show {
+      display: block;
+  }
+
+  .item-container {
+      display: flex;
+      justify-content: space-between;
+  }
+
+  .item-content {
+      margin-bottom: auto;
+      margin-top: auto;
+  }
+
+  .arrow {
+      width: 13px;
+      height: 13px;
+      display: inline-block;
+      position: relative;
+      bottom: -5px;
+      left: -10px;
+      transition: 0.4s ease;
+      margin-top: 2px;
+      text-align: left;
+      transform: rotate(45deg);
+      float: right;
+  }
+  .arrow:before, .arrow:after {
+      position: absolute;
+      content: '';
+      display: inline-block;
+      width: 12px;
+      height: 3px;
+      background-color: #fff;
+      transition: 0.4s ease;
+  }
+  .arrow:after {
+      position: absolute;
+      transform: rotate(90deg);
+      top: -5px;
+      left: 5px;
+  }
+  </style>
+{% endblock %}
 {%- block content -%}
 
 <h2><a href="/">Dataset Hoster</a> : {{ slug }}</h2>
@@ -66,4 +135,18 @@
 {% endblock %}
 
 {% block scripts %}
+  {{ super() }}
+  <script>
+    /* When the user clicks on the button, toggle between hiding and showing the dropdown content */
+    function toggleDropdown(dropdown_id) {
+        document.getElementById(dropdown_id).querySelector(".dropdown-content").classList.toggle("show");
+    }
+    document.addEventListener("click", (event) => {
+        console.log(event.target);
+        if(event.target.closest(".dropdown")) return;
+        for (const element of document.querySelectorAll(".dropdown-content")) {
+            element.classList.remove("show");
+        }
+    })
+  </script>
 {% endblock %}

--- a/example/example.py
+++ b/example/example.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python3
-import json
 from datetime import datetime
 from enum import Enum
-from typing import List, Union, Optional
-from uuid import UUID
+from typing import List
 
-from markupsafe import Markup
 from pydantic import BaseModel
 
-from datasethoster import Query, RequestSource, QueryOutputLine
+from datasethoster import Query
 
 
 class ExampleOutput(BaseModel):
     number: int
-    num_lines: int
-    x: str
+    multiplied: int
+
+
+class ExampleInput2(BaseModel):
+    number: int
+    multiplied: int
+
+class ExampleOutput2(BaseModel):
+    number: int
+    added: int
 
 
 class ExampleQuery(Query[BaseModel, ExampleOutput]):
@@ -42,7 +47,6 @@ class ExampleQuery(Query[BaseModel, ExampleOutput]):
         return ExampleOutput
 
     def fetch(self, params: list, source, offset=-1, count=-1) -> List[ExampleOutput]:
-        print(params)
         data = []
         for param in params:
             number = param.number
@@ -53,4 +57,34 @@ class ExampleQuery(Query[BaseModel, ExampleOutput]):
                     'option': param.x
                 })
         outputs = [ExampleOutput(number=x["number"], num_lines=x["multiplied"], x=x["option"].value) for x in data]
+        return outputs
+
+
+class ExampleQuery2(Query[ExampleInput2, ExampleOutput2]):
+
+    def setup(self):
+        pass
+
+    def names(self):
+        return "example-2", "Useless arithmetic addition example"
+
+    def introduction(self):
+        return """This is the introduction, which could provide more useful info that this introduction does."""
+
+    def inputs(self):
+        return ExampleInput2
+
+    def outputs(self):
+        return ExampleOutput
+
+    def fetch(self, params: List[ExampleInput2], source, offset=-1, count=-1) -> List[ExampleOutput2]:
+        data = []
+        for param in params:
+            number = param.number
+            for i in range(1, param.multiplied + 1):
+                data.append({
+                    'number': i,
+                    'added': i + number
+                })
+        outputs = [ExampleOutput2(number=x["number"], added=x["added"]) for x in data]
         return outputs

--- a/example/main.py
+++ b/example/main.py
@@ -1,8 +1,9 @@
 from datasethoster.main import create_app, register_query
 
-from example import ExampleQuery
+from example import ExampleQuery, ExampleQuery2
 
 register_query(ExampleQuery())
+register_query(ExampleQuery2())
 
 # Needs to be after register_query
 app = create_app('config')


### PR DESCRIPTION
This branch contains commits from pydantic support PR, since the [PR](https://github.com/metabrainz/data-set-hoster/pull/12) was not merged and these changes follow it, I had to create this conflicting PR.

Description about the changes - 
Changes will allow to have a dropdown to the right of each of the artist_mbids, the dropdown should have one item for each type of query on the dataset hoster that accepts artist_mbid as an argument. If the user selects that item a new browser tab opens and that query is run. If there is another argument like  algorithm which was also present in the current query use the same value to start the new query. Thus, allowing to see the similar results.

More details can be found over [here](https://tickets.metabrainz.org/browse/LB-1249).